### PR TITLE
Layout: Ajustar responsividade do bloco Stack (#25)

### DIFF
--- a/src/blocks/StackBlock/StackBlock.module.css
+++ b/src/blocks/StackBlock/StackBlock.module.css
@@ -23,7 +23,7 @@
 
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 16px 16px;
+  gap: 16px;
   align-items: center;
 }
 
@@ -44,6 +44,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 
   color: inherit;
   transition: opacity 0.15s ease;


### PR DESCRIPTION
- Prepara o bloco Stack para responsividade, que será resolvido no grid como um todo, já que o objeto não existe de forma independente

Closes #25 