### PR TITLE
Layout: Cria e estiliza o bloco Contato #29

### DIFF
--- a/src/blocks/ContactBlock/ContactBlock.module.css
+++ b/src/blocks/ContactBlock/ContactBlock.module.css
@@ -1,0 +1,58 @@
+.container {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.icon {
+  width: 46px;
+  height: 46px;
+  display: block;
+  color: inherit;
+  flex-shrink: 0;
+}
+
+.text {
+  margin: 0;
+  max-width: 28ch;
+  text-align: center;
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  line-height: 1.45;
+}
+
+.email {
+  width: fit-content;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+  font-size: 1.15rem;
+  line-height: 1.4;
+  transition: opacity 0.15s ease;
+}
+
+.email:hover {
+  opacity: 0.6;
+}
+
+.email:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 4px;
+}

--- a/src/blocks/ContactBlock/ContactBlock.tsx
+++ b/src/blocks/ContactBlock/ContactBlock.tsx
@@ -1,0 +1,37 @@
+import styles from "./ContactBlock.module.css";
+import type { ContactBlockDictionary } from "@/data/dictionaries/types";
+import { FiMail } from "react-icons/fi";
+
+type ContactBlockProps = {
+  dictionary: ContactBlockDictionary;
+};
+
+export function ContactBlock({ dictionary }: ContactBlockProps) {
+  return (
+    <section
+      className={styles.container}
+      aria-labelledby="contact-heading"
+    >
+      <h1
+        id="contact-heading"
+        className={styles.visuallyHidden}
+      >
+        {dictionary.title}
+      </h1>
+
+      <FiMail className={styles.icon} aria-hidden="true" />
+
+      <p className={styles.text}>
+        {dictionary.text}
+      </p>
+
+      <a
+        href={`mailto:${dictionary.email}`}
+        className={styles.email}
+        aria-label={`Email ${dictionary.email}`}
+      >
+        {dictionary.email}
+      </a>
+    </section>
+  );
+}

--- a/src/blocks/ContactBlock/index.ts
+++ b/src/blocks/ContactBlock/index.ts
@@ -1,0 +1,1 @@
+export { ContactBlock } from "./ContactBlock";

--- a/src/components/home/HomepageBlocks.tsx
+++ b/src/components/home/HomepageBlocks.tsx
@@ -6,6 +6,7 @@ import { homeBlocks } from "@/data/blocks/homeBlocks";
 import { SpacerBlock } from "@/blocks/SpacerBlock";
 import { SocialLinksBlock } from "@/blocks/SocialLinksBlock";
 import { StackBlock } from "@/blocks/StackBlock";
+import { ContactBlock } from "@/blocks/ContactBlock";
 import { LanguageToggleBlock } from "@/blocks/LanguageToggleBlock";
 import { useI18n } from "@/components/i18n/I18nProvider";
 
@@ -29,6 +30,9 @@ export function HomepageBlocks() {
 
       case "stack":
         return <StackBlock dictionary={dict.stackBlock} />;
+
+      case "contact":
+        return <ContactBlock dictionary={dict.contactBlock} />;
 
       default:
         return block.label ?? block.type;

--- a/src/data/dictionaries/en.ts
+++ b/src/data/dictionaries/en.ts
@@ -6,6 +6,7 @@ export const en: Dictionary = {
     about: 'About',
     contact: 'Contact',
   },
+
   stackBlock: {
     sentence: 'technologies and tools I use to build my projects',
     items: {
@@ -21,5 +22,11 @@ export const en: Dictionary = {
       gitGithub: 'Git/GitHub',
       vscode: 'VSCode',
     },
+  },
+
+  contactBlock: {
+    title: "Contact",
+    text: "if you'd like to talk about a project, a collaboration, or just say hello, you can reach me at:",
+    email: "castelhanoc@gmail.com",
   },
 };

--- a/src/data/dictionaries/pt.ts
+++ b/src/data/dictionaries/pt.ts
@@ -6,6 +6,7 @@ export const pt: Dictionary = {
     about: 'Sobre',
     contact: 'Contato',
   },
+
   stackBlock: {
     sentence: 'tecnologias e ferramentas que utilizo nos meus projetos',
     items: {
@@ -21,5 +22,11 @@ export const pt: Dictionary = {
       gitGithub: 'Git/GitHub',
       vscode: 'VSCode',
     },
+  },
+  
+  contactBlock: {
+    title: "Contato",
+    text: "se quiser conversar sobre um projeto, uma colaboração ou apenas trocar uma ideia, você pode me escrever em:",
+    email: "castelhanoc@gmail.com",
   },
 };

--- a/src/data/dictionaries/types.ts
+++ b/src/data/dictionaries/types.ts
@@ -1,21 +1,27 @@
-export type Locale = 'pt' | 'en';
+export type Locale = "pt" | "en";
 
 export type StackItemId =
-  | 'html'
-  | 'css'
-  | 'javascript'
-  | 'rails'
-  | 'typescript'
-  | 'figma'
-  | 'nextjs'
-  | 'react'
-  | 'sql'
-  | 'gitGithub'
-  | 'vscode';
+  | "html"
+  | "css"
+  | "javascript"
+  | "rails"
+  | "typescript"
+  | "figma"
+  | "nextjs"
+  | "react"
+  | "sql"
+  | "gitGithub"
+  | "vscode";
 
 export type StackBlockDictionary = {
   sentence: string;
   items: Record<StackItemId, string>;
+};
+
+export type ContactBlockDictionary = {
+  title: string;
+  text: string;
+  email: string;
 };
 
 export type Dictionary = {
@@ -25,4 +31,5 @@ export type Dictionary = {
     contact: string;
   };
   stackBlock: StackBlockDictionary;
+  contactBlock: ContactBlockDictionary;
 };


### PR DESCRIPTION
- Cria o bloco Contato com suporte para o dicionário pt/en;
- Estiliza o bloco Contato com textos e ícones de acordo com o layout das outras seções e ícones React;
- Importa o bloco Contato no grid;
- Implementa acessibilidade no bloco com visually hidden e outras características.

Closes #29 